### PR TITLE
Add monte carlo simulation scripts

### DIFF
--- a/AzurePipeline.yaml
+++ b/AzurePipeline.yaml
@@ -13,7 +13,8 @@ schedules:
 name: $(Date:yyyy.MM.dd)$(Rev:.r)
 
 jobs:
-  - job: CalculateWorkItemAge
+  - job: RunAzureDevopsPythonScripts
+    displayName: Run Azure DevOps Python Scripts
 
     pool: 
       vmImage: ubuntu-latest
@@ -24,8 +25,15 @@ jobs:
       - script: "python -m pip install -r requirements.txt"
         displayName: "Install Python prerequisites"
 
-
       # You don't want to put your PAT in the yaml file, make sure to use some kind of (secret) variable!
+
+      - task: PythonScript@0
+        displayName: Run Monte Carlo Simulation
+        inputs:
+          scriptSource: 'filePath'
+          scriptPath: '$(System.DefaultWorkingDirectory)/MonteCarlo.py'
+          arguments: '--OrganizationUrl "https://dev.azure.com/huserben/" --PersonalAccessToken "******" --ReleaseTag "MyProduct v1.33.7" --TargetDate "08.04.2024" --GoalTag "SprintGoal" --IterationLength "7"'
+
 
       - task: PythonScript@0
         displayName: Update Work Item Age

--- a/CalculateWorkItemAge.py
+++ b/CalculateWorkItemAge.py
@@ -1,6 +1,6 @@
 from msrest.authentication import BasicAuthentication
 from azure.devops.connection import Connection
-from azure.devops.v5_1.work_item_tracking.models import Wiql
+from azure.devops.v7_1.work_item_tracking.models import Wiql
 from datetime import date, datetime
 
 import argparse

--- a/Classes/Prediction.py
+++ b/Classes/Prediction.py
@@ -1,0 +1,23 @@
+import os
+
+class Prediction:
+    
+    def __init__(self, work_item_types, run_prediction, relevant_history_in_days, done_states, area_paths):
+        self.work_item_types = work_item_types
+        self.run_prediction = run_prediction
+        self.relevant_history_in_days = int(relevant_history_in_days)
+        self.done_states = done_states
+        self.area_paths = area_paths
+        
+        self.remaining_items = 0
+        
+        self.how_many_50 = 0
+        self.how_many_85 = 0
+        self.how_many_95 = 0
+        
+        self.when_50 = None
+        self.when_85 = None
+        self.when_95 = None
+        
+        self.target_date_likelyhood = None
+        self.target_date = None

--- a/Classes/WorkItem.py
+++ b/Classes/WorkItem.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+
+class WorkItem:
+    def __init__(self, id, title, type, state, tags, boardColumn, closedDate, state_changed_date, area_path, iteration_path):
+        self.id = id
+        self.title = title.replace("'", "")
+        self.type = type
+        self.state = state
+        self.tags = tags
+        self.boardColumn = boardColumn
+        self.area_path = area_path
+        self.iteration_path = iteration_path
+        
+        if closedDate == "N/A":
+            self.closedDate = None
+        else:        
+            self.closedDate = closedDate
+            
+        if state_changed_date == "N/A":
+            self.state_changed_date = None
+        else:
+            self.state_changed_date = state_changed_date
+            
+    def parse_ado_date(self, date):
+        try:
+            return datetime.strptime(date, "%Y-%m-%dT%H:%M:%S.%fZ")
+        except:
+            return datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ")
+        
+    def contains_tag(self, tag):
+        for existing_tag in self.tags.split(";"):
+            if tag == existing_tag.strip():
+                return True
+        
+        return False
+            
+    def to_dict(self):
+            if self.closedDate != None:
+                parsed_closed_date = self.parse_ado_date(self.closedDate)
+            else:
+                parsed_closed_date = datetime.min
+                
+            if self.state_changed_date != None:
+                parsed_state_changed = self.parse_ado_date(self.state_changed_date)
+            else:
+                parsed_state_changed = datetime.min
+                
+            return {
+                'id': self.id,
+                'title': self.title,
+                'type': self.type,
+                'state': self.state,
+                'boardColumn': self.boardColumn,
+                'closedDate': parsed_closed_date.date(),
+                'state_changed_date': parsed_state_changed.date(),
+            }

--- a/MonteCarlo.py
+++ b/MonteCarlo.py
@@ -1,0 +1,172 @@
+import argparse
+import datetime
+
+from Services.WorkItemService import WorkItemService
+from Services.MonteCarloService import MonteCarloService
+
+from Classes.Prediction import Prediction
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--PersonalAccessToken")
+parser.add_argument("--OrganizationUrl")
+parser.add_argument("--ReleaseTag")
+parser.add_argument("--TargetDate")
+parser.add_argument("--GoalTag")
+parser.add_argument("--IterationLength")
+
+args = parser.parse_args()
+
+work_item_service = WorkItemService(args.OrganizationUrl, args.PersonalAccessToken)
+
+release_tag = args.ReleaseTag
+goal_tag = args.GoalTag
+target_date = None
+if args.TargetDate:
+    target_date = datetime.datetime.strptime(args.TargetDate, "%d.%m.%Y").date()
+
+iteration_length = None
+if args.IterationLength:
+    iteration_length =  int(args.IterationLength)
+
+                # Work Item Types, Enable Prediction, History in Days, Done States, Area Paths
+predictions = [ Prediction(["Epic"], False, 180, ["Closed", "Resolved"], ["MyProduct\MyAreaPath"]),
+                Prediction(["Feature"], False, 120, ["Closed","Resolved"], []),
+                Prediction(["User Story", "Bug"], True, 90, ["Closed"], ["MyProduct\MyAreaPath"])]
+
+def get_remaining_items_by_tag_and_type(work_item_types, tag):    
+    print("Fetching items linked to Tag {0}:".format(tag))
+    work_items = work_item_service.get_open_items_by_tag(tag)
+    
+    remaining_items = []   
+    
+    for item in work_items:
+        if item.type in work_item_types:
+          remaining_items.append(item)
+          print("{0} - {1} - {2} - {3} - {4} - {5} - {6} - {7}".format(item.id, item.type, item.title, item.state, item.tags, item.boardColumn, item.closedDate, item.area_path))
+    
+    remaining_items = len(remaining_items)
+    
+    print("{0} Items remaining".format(remaining_items))
+    return remaining_items
+
+def get_closed_items_history(prediction):
+    start_date = datetime.datetime.now() - datetime.timedelta(prediction.relevant_history_in_days)
+    
+    work_items = work_item_service.get_items_by_area_paths(prediction.work_item_types, prediction.area_paths, [], start_date.strftime("%m-%d-%Y"))
+    closed_items_history = monte_carlo_service.create_closed_items_history(work_items)
+    return closed_items_history
+
+def add_forecast_to_prediction(prediction, how_many_50, how_many_85, how_many_95, when_50, when_85, when_95, target_date, target_date_likelyhood):
+    prediction.how_many_50 = how_many_50
+    prediction.how_many_85 = how_many_85
+    prediction.how_many_95 = how_many_95
+    
+    prediction.when_50 = when_50
+    prediction.when_85 = when_85
+    prediction.when_95 = when_95
+    
+    prediction.target_date_likelyhood = target_date_likelyhood
+    prediction.target_date = target_date
+
+print("================================================================")
+print("Starting Monte Carlo Simulation...")
+print("================================================================")  
+print("Parameters:")
+print("OrganizationUrl: {0}".format(args.OrganizationUrl))
+print("ReleaseTag: {0}".format(args.ReleaseTag))
+print("TargetDate: {0}".format(args.TargetDate))
+print("GoalTag: {0}".format(args.GoalTag))
+print("IterationLength: {0}".format(args.IterationLength))
+print("----------------------------------------------------------------")
+   
+for prediction in predictions.copy():        
+    if prediction.run_prediction == False:            
+        print("Predictions for {0} disabled - skipping".format(prediction.work_item_types))
+        continue
+
+    monte_carlo_service = MonteCarloService(prediction)
+
+    print("Running Prediction for work item type '{0}' and Area Path '{1}'".format(prediction.work_item_types, prediction.area_paths))    
+    
+    closed_items_history = get_closed_items_history(prediction)        
+    if len(closed_items_history) < 1:
+        print("No closed items - skipping prediction")
+        continue
+    
+    ## Run How Many Predictions via Monte Carlo Simulation - only possible if we have a target date set
+    predictions_howmany_50 = predictions_howmany_85 = predictions_howmany_95 = 0
+    if target_date:
+        (predictions_howmany_50, predictions_howmany_85, predictions_howmany_95) = monte_carlo_service.how_many(target_date, closed_items_history)       
+    
+    
+    ## Run When Predictions via Monte Carlo Simulation - only possible if we have an item tag set to fetch how many items are remaining
+    predictions_when_50 = predictions_when_85 = predictions_when_95 = datetime.date.today()
+    predictions_targetdate_likelyhood = None
+    
+    if release_tag:
+        remaining_items = get_remaining_items_by_tag_and_type(prediction.work_item_types, release_tag)            
+        prediction.remaining_items = remaining_items            
+        if remaining_items > 0:              
+            (predictions_when_50, predictions_when_85, predictions_when_95, predictions_targetdate_likelyhood) = monte_carlo_service.when(remaining_items, closed_items_history, target_date)
+    
+    add_forecast_to_prediction(prediction, predictions_howmany_50, predictions_howmany_85, predictions_howmany_95, predictions_when_50, predictions_when_85, predictions_when_95, target_date, predictions_targetdate_likelyhood)
+    
+    ## Run Sprint Predictions
+    if "User Story" in prediction.work_item_types and (iteration_length or goal_tag):       
+        iteration_prediction = Prediction(["Iteration"], True, 90, "Closed", [])
+        
+        print("Read Sprint Prediction settings: Iteration Length is {0} and Tag is {1}".format(iteration_length, goal_tag))
+        
+        predictions_when_50 = predictions_when_85 = predictions_when_95 = datetime.date.today()
+        predictions_targetdate_likelyhood = None
+        
+        if goal_tag:
+            print("Checking how many items with tag '{0}' are pending".format(goal_tag))
+            remaining_items_for_sprint = get_remaining_items_by_tag_and_type(prediction.work_item_types, goal_tag)      
+            iteration_prediction.remaining_items = remaining_items_for_sprint
+            
+            if remaining_items_for_sprint >= 1:
+                print("{0} '{1}' Items are pending...".format(remaining_items_for_sprint, goal_tag))
+                (predictions_when_50, predictions_when_85, predictions_when_95, predictions_targetdate_likelyhood) = monte_carlo_service.when(remaining_items_for_sprint, closed_items_history, datetime.date.today())
+            else:
+                print("No remaining items left - skipping prediction")
+        
+        predictions_howmany_50 = predictions_howmany_85 = predictions_howmany_95 = 0
+        iteration_target_date = datetime.date.today()
+        if iteration_length:
+            print("Checking how many items can be done in the next {0} days".format(iteration_length))
+            iteration_target_date = (datetime.datetime.now() + datetime.timedelta(days = iteration_length)).date()
+            
+            (predictions_howmany_50, predictions_howmany_85, predictions_howmany_95) = monte_carlo_service.how_many(iteration_target_date, closed_items_history)
+        
+        add_forecast_to_prediction(iteration_prediction, predictions_howmany_50, predictions_howmany_85, predictions_howmany_95, predictions_when_50, predictions_when_85, predictions_when_95, iteration_target_date, predictions_targetdate_likelyhood)
+        
+        predictions.append(iteration_prediction)
+        
+print("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+print("Summary")
+print("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+
+for prediction in predictions:            
+    print("================================================================")
+    if prediction.run_prediction == False:            
+        print("Predictions for {0} disabled - skipping".format(prediction.work_item_types))
+        print("================================================================")
+        continue
+    
+    print("Predictions for {0}:".format(prediction.work_item_types))
+    print("================================================================")
+    
+    print("How many items will be done by {0}:".format(prediction.target_date))
+    print("50%: {0}".format(prediction.how_many_50))
+    print("85%: {0}".format(prediction.how_many_85))
+    print("95%: {0}".format(prediction.how_many_95))
+    print("----------------------------------------")
+    
+    if prediction.remaining_items != 0:
+        print("When will {0} items be done:".format(prediction.remaining_items))
+        print("50%: {0}".format(prediction.when_50))
+        print("85%: {0}".format(prediction.when_85))
+        print("95%: {0}".format(prediction.when_95))
+        print("----------------------------------------")
+        print("Chance of Target Date: {0} - {1}".format(target_date, prediction.target_date_likelyhood))

--- a/README.md
+++ b/README.md
@@ -5,6 +5,56 @@ Make sure you have python 3.x installed on your system and it's available via yo
 
 Then run `python -m pip install -r .\requirements.txt` from this directory to install the packages.
 
+## Run Monte Carlo (MC) Simulations
+Let's you run MC Simulations based on your items in Azure DevOps.
+The script supports "How Many" and "When" simulations, forecasting how many items till a specific date might be done as well as when 'x' amount of items will be done (based on tags).
+
+The script will only read data from your Azure DevOps Organization, so you won't need any special permissions.
+You can run it as follows from your local machine:
+`python .\MonteCarlo.py --OrganizationUrl "https://dev.azure.com/huserben/" --PersonalAccessToken "***********" --ReleaseTag "MyProduct v1.33.7" --TargetDate "08.04.2024" --GoalTag "SprintGoal" --IterationLength "7"`
+
+- This will run the MC Simulations against items in the Azure DevOps org *huserben*.
+- It will forecast how long it will take to close the items that contain a tag called *MyProduct v1.33.7*.
+- It will forecast how many items you'll be able to close till *08.04.2024*
+- Furthermore it will calculate how long it will take to close items tagged with *SprintGoal* and how many items you'll be able to close within the next *7* days
+
+The results will be presented in the output. At the end of the script there will be a summary with the forecasts.
+
+Feel free to adjust the script based on your need, for example by adding a way to export the data.
+
+**Note:** While it's ok to run it manually, I highly advise to run the script continuously. See *Pipeline Integration* at the bottom.
+
+### Prediction Configuration
+You can configure predictions as part of the script (see line 30 in *MonteCarlo.py* that starts with `predictions = [...`).
+
+You can run predictions per "Work Item Type". For example you can run the predictions for your Epics and another forecast for your User Stories & Bugs.
+
+Adjust the following lines as you wish in the script:
+
+```
+predictions = [ Prediction(["Epic"], False, 180, ["Closed", "Resolved"], ["MyProduct\MyAreaPath"]),
+                Prediction(["User Story", "Bug"], True, 90, ["Closed"], ["MyProduct\MyAreaPath"])]
+```
+
+Every *Prediction* contains:
+- The work item types the prediction should be run for (["Epic"] / ["User Story", "Bug"])
+- Whether the predictions is active (True/False)
+- How far back in history (in days) the data should be taken in to account for the simulation (180, 90)
+- What work item states states are considered "done" for the forecast (["Closed", "Resolved"], ["Closed"])
+- What area path the items are in (multiple paths are possible)
+
+**Notice:** Be aware that depending on your template your work item types and states can differ (e.g. you might have "Product Backlog Item" and "Done" instead of "User Story" and "Closed")
+
+After you've configured the predictions you want, save the file and run the script.
+
+### Arguments
+- Organization Url: The url to your Azure DevOps Organization. **Mandatory**
+- Personal Access Token: A token that has the Work Items Read & Write scope active. **Mandatory**
+- ReleaseTag: Tag to identify items for which the *When* forecast should be run. *Optional*
+- TargetDate: Date for which the *How Many* forecast should be run. *Optional*
+- GoalTag: Tag to identify the teams current goal (e.g. Sprint Goal). If set, a *When* forecast will be run for those items. *Optional*
+- IterationLength: Length of your iteration in days. If set, a *How Many* forecast will be run for the amount of days. *Optional*
+
 ## Calculate Work Item Age
 Let's you update the age of your work items on Azure DevOps according to the following formula: `(Today - Start Date) + 1`
 where the Start Date is the day when the item was moved out of the "New" state.
@@ -29,5 +79,5 @@ As an example, if you want to write the age data in to the "Story Points" field,
 `python .\CalculateWorkItemAge.py --OrganizationUrl "https://dev.azure.com/huserben/" --TeamProject "WIA_Demo" --PersonalAccessToken "***********" --FieldName "Story Points" --TrialRun "False"`
 
 ## Pipeline Integration
-You want to run this script on a regular base. As we humans tend to forget this, I propose that you leverage your Azure Pipelines for this. I've included a "sample" in *AzurePipeline.yaml* that shows how you can run the script from there.
-Use and adjust as you please.
+You want to run this script on a regular base. As we humans tend to forget this, I propose that you leverage your Azure Pipelines for this. I've included a "sample" in *AzurePipeline.yaml* that shows how you can run the scripts from there.
+Use and adjust as you see fit.

--- a/Services/MonteCarloService.py
+++ b/Services/MonteCarloService.py
@@ -1,0 +1,188 @@
+import random
+from datetime import date, timedelta
+import matplotlib.pyplot as plt
+import pandas as pd
+
+class MonteCarloService:
+    
+    def __init__(self, prediction_settings, trials=100000):
+        self.trials = trials
+        
+        self.prediction_settings = prediction_settings
+        
+        self.percentile_50 = 0.5
+        self.percentile_85 = 0.85
+        self.percentile_95 = 0.95
+        
+    def create_closed_items_history(self, items):
+        print("Getting items that were done in the last {0} days...".format(self.prediction_settings.relevant_history_in_days))       
+        time_delta = date.today() - timedelta(self.prediction_settings.relevant_history_in_days)
+        df = pd.DataFrame.from_records([item.to_dict() for item in items])
+        
+        print("Following states are considered 'Done': {0}".format(self.prediction_settings.done_states))
+        
+        closed_items = pd.DataFrame()
+        
+        for done_state in self.prediction_settings.done_states:
+            closed_items = pd.concat([closed_items, df[(df.state == done_state.strip()) & (df.state_changed_date >= time_delta)]])        
+        
+        closed_items_hist = closed_items["state_changed_date"].value_counts().to_dict()
+        
+        print("Found {0} items that were closed in the last {1} days".format(len(closed_items), self.prediction_settings.relevant_history_in_days))
+                    
+        return closed_items_hist
+    
+    def how_many(self, target_date, closed_items_history):
+        print("--------------------------------")
+        print("Running Monte Carlo Simulation - How Many items will be done till {0}".format(target_date))
+        print("--------------------------------")
+        monte_carlo_simulation_results = self.__run_monte_carlo_how_many(target_date, closed_items_history)
+        
+        return self.__get_predictions_howmany(monte_carlo_simulation_results)
+        
+    def when(self, remaining_items, closed_items_history, target_date = None):
+        print("--------------------------------")
+        print("Running Monte Carlo Simulation - When will {0} items be done".format(remaining_items))
+        print("--------------------------------")
+        monte_carlo_simulation_results = self.__run_monte_carlo_when(remaining_items, closed_items_history)
+        
+        days_to_target_date = None
+        if target_date:
+            days_to_target_date = (target_date - date.today()).days
+            print("{0} days to target date".format(days_to_target_date))
+        
+        (predicted_date_50, predicted_date_85, predicted_date_95, target_date_likelyhood) = self.__get_predictions_when(monte_carlo_simulation_results, days_to_target_date)
+        return (predicted_date_50, predicted_date_85, predicted_date_95, target_date_likelyhood)
+
+    def __run_monte_carlo_when(self, remaining_items, closed_items_history):        
+        time_delta = date.today() - timedelta(self.prediction_settings.relevant_history_in_days)
+        monte_carlo_data = self.__prepare_monte_carlo_dataset(time_delta, closed_items_history)            
+                
+        mc_results = {}
+                
+        for i in range(self.trials):
+            day_count = 0
+            finished_item_count = 0
+                    
+            while finished_item_count < remaining_items:
+                day_count += 1
+                rand = random.randint(0, self.prediction_settings.relevant_history_in_days - 1)
+                finished_item_count += monte_carlo_data[rand]
+                        
+            if day_count in mc_results:
+                mc_results[day_count] += 1
+            else:
+                mc_results[day_count] = 1
+                
+        return mc_results
+
+    def __get_predictions_when(self, mc_results, days_to_target_date = None):        
+        sorted_dict = {k:v for k,v in sorted(mc_results.items())}
+                
+        percentile_50_target = self.trials * 0.5
+        percentile_85_target = self.trials * 0.85
+        percentile_95_target = self.trials * 0.95
+        percentile_50 = 0
+        percentile_85 = 0
+        percentile_95 = 0
+        
+        # Initialize trials in time with the number of trials - if we have 100% chance of hitting the target date, we don't need to calculate it
+        trials_in_time = self.trials if days_to_target_date else -1
+        
+        count = 0
+                    
+        for key in sorted_dict:
+            value = sorted_dict[key]
+
+            count += value
+                    
+            if (percentile_50 == 0 and count >= percentile_50_target):
+                percentile_50 = key
+            elif (percentile_85 == 0 and count >= percentile_85_target):
+                percentile_85 = key
+            elif (percentile_95 == 0 and count >= percentile_95_target):
+                percentile_95 = key
+                
+            if trials_in_time == self.trials and key >= days_to_target_date:
+                trials_in_time = count
+                
+        
+        predicted_date_50 = date.today() + timedelta(percentile_50)
+        predicted_date_85 = date.today() + timedelta(percentile_85)
+        predicted_date_95 = date.today() + timedelta(percentile_95)
+        print("50 Percentile: {0} days - Predicted Date: {1}".format(percentile_50, predicted_date_50))
+        print("85 Percentile: {0} days - Predicted Date: {1}".format(percentile_85, predicted_date_85))
+        print("95 Percentile: {0} days - Predicted Date: {1}".format(percentile_95, predicted_date_95))
+        
+        prediction_targetdate = 0
+        if days_to_target_date:
+            prediction_targetdate = (100 / self.trials) * trials_in_time
+            print("Chance of hitting target date: {0}".format(prediction_targetdate))
+        
+        return (predicted_date_50, predicted_date_85, predicted_date_95, prediction_targetdate)
+
+    def __run_monte_carlo_how_many(self, prediction_date, closed_items_hist):
+        time_delta = date.today() - timedelta(self.prediction_settings.relevant_history_in_days)
+        monte_carlo_data = self.__prepare_monte_carlo_dataset(time_delta, closed_items_hist)            
+                
+        mc_results = {}
+        amount_of_days = (prediction_date - date.today()).days
+                
+        for i in range(self.trials):
+            day_count = 0
+            finished_item_count = 0
+                    
+            while day_count < amount_of_days:
+                day_count += 1
+                rand = random.randint(0, self.prediction_settings.relevant_history_in_days - 1)
+                finished_item_count += monte_carlo_data[rand]
+                        
+            if finished_item_count in mc_results:
+                mc_results[finished_item_count] += 1
+            else:
+                mc_results[finished_item_count] = 1
+                
+        return mc_results
+
+    def __get_predictions_howmany(self, mc_results):        
+        sorted_dict = {k:v for k,v in sorted(mc_results.items(), reverse=True)}
+                
+        percentile_50_target = self.trials * self.percentile_50
+        percentile_85_target = self.trials * self.percentile_85
+        percentile_95_target = self.trials * self.percentile_95
+        percentile_50 = 0
+        percentile_85 = 0
+        percentile_95 = 0
+        count = 0
+                
+        for key in sorted_dict:
+            value = sorted_dict[key]
+
+            count += value
+                    
+            if (percentile_50 == 0 and count >= percentile_50_target):
+                percentile_50 = key
+            elif (percentile_85 == 0 and count >= percentile_85_target):
+                percentile_85 = key
+            elif (percentile_95 == 0 and count >= percentile_95_target):
+                percentile_95 = key
+                
+                
+        print("50 Percentile: {0} Items".format(percentile_50))
+        print("85 Percentile: {0} Items".format(percentile_85))
+        print("95 Percentile: {0} Items".format(percentile_95))
+        
+        return (percentile_50, percentile_85, percentile_95)
+
+    def __prepare_monte_carlo_dataset(self, time_delta, closed_items_hist):
+        monte_carlo_data = {}
+        
+        for i in range((date.today() - time_delta).days):
+            day = date.today() - timedelta(days=i)
+            monte_carlo_data[i] = 0
+
+            if day in closed_items_hist:
+                monte_carlo_data[i] = closed_items_hist[day]
+                
+        
+        return monte_carlo_data       

--- a/Services/WorkItemService.py
+++ b/Services/WorkItemService.py
@@ -1,0 +1,127 @@
+from Classes.WorkItem import WorkItem
+from azure.devops.connection import Connection
+from msrest.authentication import BasicAuthentication
+from azure.devops.v7_1.work_item_tracking.models import Wiql
+from collections import deque
+
+class WorkItemService:    
+    
+    def __init__(self, org_url, token):
+        credentials = BasicAuthentication('', token)
+        
+        self.organization_url = org_url
+        self.personal_access_token = token
+        
+        self.header_patch = {'Content-Type': 'application/json-patch+json'}
+        
+        self.connection = Connection(base_url=org_url, creds=credentials)
+        self.wit_client = self.connection.clients.get_work_item_tracking_client()
+    
+    def get_items_via_wiql(self, wiql):
+        wiql_results = self.wit_client.query_by_wiql(wiql).work_items
+
+        if wiql_results:
+            work_items = (self.wit_client.get_work_item(int(res.id), expand='Relations') for res in wiql_results)
+            return work_items
+        else:
+            return []
+    
+
+    def get_items_by_tag(self, tag):
+        wiql = Wiql(
+                query="""
+                select [System.Id]
+                from WorkItems
+                where [System.Tags] contains '{0}' """
+            .format(tag)
+            )
+
+        return self.get_items_via_wiql(wiql)
+        
+    def get_items_by_area_path(self, work_item_type, area_path, starting_date = None):
+        
+        starting_date_statement = ""
+        if starting_date:
+            starting_date_statement = "AND [System.ChangedDate] >= '{0}'".format(starting_date)
+        
+        wiql = Wiql(
+                query="""
+                select [System.Id]
+                from WorkItems
+                where [System.WorkItemType] = '{0}'
+                and [System.AreaPath] under '{1}'
+                {2}"""
+            .format(work_item_type, area_path, starting_date_statement)
+            )
+
+        return self.get_items_via_wiql(wiql)
+        
+    
+    def get_open_items_by_tag(self, tag):
+        work_items = []
+        for wiql_result in self.get_items_by_tag(tag):
+                work_item = self.convert_to_work_item(wiql_result)
+                
+                if work_item.state != "Closed" and work_item.state != "Done":
+                    work_items.append(work_item)
+                    
+        return work_items
+       
+       
+    def get_items_by_area_paths(self, work_item_types, area_paths, excluded_tags = [], starting_date = None):
+        print("Getting work items of type {0} and within area paths {1} - This might take a while".format(work_item_types, area_paths))
+        work_items = []
+        
+        for area_path in area_paths:
+            for work_item_type in work_item_types:
+                for wiql_result in self.get_items_by_area_path(work_item_type, area_path, starting_date):
+                    work_item = self.convert_to_work_item(wiql_result)
+                    
+                    skip_work_item = False
+                    
+                    for excluded_tag in excluded_tags:
+                        if work_item.contains_tag(excluded_tag):
+                            skip_work_item = True
+                            break
+                    
+                    if not skip_work_item:
+                        work_items.append(work_item)
+        
+        return work_items
+   
+
+    def convert_to_work_item(self, wiql_result):
+        type = "N/A"
+        if 'System.WorkItemType' in wiql_result.fields:
+            type = wiql_result.fields["System.WorkItemType"]
+        title = "N/A"
+        if 'System.Title' in wiql_result.fields:
+            title = wiql_result.fields["System.Title"]
+        state = "N/A"
+        if 'System.State' in wiql_result.fields:
+            state = wiql_result.fields["System.State"]
+        tags = "N/A"
+        if 'System.Tags' in wiql_result.fields:
+            tags = wiql_result.fields["System.Tags"]
+        boardColumn = "N/A"
+        if 'System.BoardColumn' in wiql_result.fields:
+            boardColumn = wiql_result.fields["System.BoardColumn"]
+        boardColumnDone = "N/A"
+        if 'System.BoardColumnDone' in wiql_result.fields:
+            boardColumnDone = wiql_result.fields["System.BoardColumnDone"]
+            
+            if boardColumnDone:
+                boardColumn += " Done"
+        closedDate = "N/A"
+        if 'Microsoft.VSTS.Common.ClosedDate' in wiql_result.fields:
+            closedDate = wiql_result.fields["Microsoft.VSTS.Common.ClosedDate"]
+        
+        state_changed_date = "N/A"
+        if "Microsoft.VSTS.Common.StateChangeDate" in wiql_result.fields:
+            state_changed_date = wiql_result.fields["Microsoft.VSTS.Common.StateChangeDate"]            
+            
+        area_path = wiql_result.fields["System.AreaPath"]       
+        iteration_path = wiql_result.fields["System.IterationPath"]
+        
+        return WorkItem(wiql_result.id, title, type, state, tags, boardColumn, closedDate, state_changed_date, area_path, iteration_path)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 argparse
 requests
 azure-devops
+pandas
+numpy
+matplotlib


### PR DESCRIPTION
Add scripts that allow to run MC simulations.

Supports
- Different predictions per run (configurable inside script, per Work Item Type)
- Release Predictions:
  - "How Many" based on Target Date
  - "When" based on Tags
- "Sprint" Forecast
  - "How Many" based on iteration length
  - "When" based on tag for Sprint Goal